### PR TITLE
Release `0.3.0`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,12 +14,14 @@ Metrics/CyclomaticComplexity:
 Metrics/AbcSize:
   Max: 25
 Metrics/ClassLength:
-  Max: 250
+  Max: 300
 Metrics/ModuleLength:
-  Max: 250
+  Max: 500
 Naming/MethodParameterName:
   MinNameLength: 2
 Style/IfUnlessModifier:
   Enabled: false
 Style/GuardClause:
+  Enabled: false
+Style/RescueStandardError:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## 0.3.0 (2021-03-14)
+
+NEW FEATURES:
+
+* Better inline help
+* Better error handling on CRUD operations
+
+BUG FIXES:
+
+* add missing default values
+  - fix error on poorly formatted policy template
+  - fix error on missing CR attributes
+* fix missing error metrics
+
 ## 0.2.0 (2021-03-01)
 
 NEW FEATURES:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cloudsap (0.2.0)
+    cloudsap (0.3.0)
       aws-sdk-eks (~> 1.41)
       aws-sdk-iam (~> 1.44)
       concurrent-ruby (~> 1.1)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,36 @@ spec:
 
 ## Running Cloudsap
 
+### Modes
+
+Cloudsap has **two mode of operation**. These modes are invoked as sub-commands to the Cloudsap CLI:
+
+1. `install`: for installing prerequisites and elements of the Cloudsap operator
+  - Example: `cloudsap install irsa --aws-region ...`
+2. `controller`: running the Cloudsap operator
+  - Example: `cloudsap controller irsa --aws-region ...`
+
+### Configuration
+
+Both the Cloudsap `install` and `controller` sub-commands can be configured via CLI options or equivalent environment variables:
+
+#### `cloudsap install COMPONENT`
+| option | env_var | description |
+| -------------  | ------------- | ------------- |
+| --aws-region   | AWS_REGION            | AWS region that hosts your EKS cluster (required) |
+| --cluster-name | CLOUDSAP_CLUSTER_NAME | Name designated for th EKS cluster (required)     |
+| --namespace    | CLOUDSAP_NAMESPACE    | Namespace in which to deploy operator (required)  |
+| --kubeconfig   | KUBECONFIG            | Path to kubeconfig file for authentication        |
+
+#### `cloudsap controller`
+| option | env_var | description |
+| -------------  | ------------- | ------------- |
+| --aws-region   | AWS_REGION            | AWS region that hosts your EKS cluster (required) |
+| --cluster-name | CLOUDSAP_CLUSTER_NAME | Name designated for th EKS cluster (required)     |
+| --oidc-issuer  | CLOUDSAP_OIDC_ISSUER  | URL of the EKS cluster's OIDC issuer              |
+| --kubeconfig   | KUBECONFIG            | Path to kubeconfig file for authentication        |
+| --debug        | CLOUDSAP_DEBUG        | Enable debug logging                              |
+
 ### Deploying to a Cluster
 
 Assuming you've already created an EKS cluster and associated Identity Provider per the instructions [here](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-console.html), the simplest way to setup is to us the `install` subcommand:
@@ -144,7 +174,7 @@ These can be AWS Default policies or ones you've devised yourself.
 
 #### Policy Templates
 
-CSAs can also be used to declare inline IAM Role Policy and have facility for templating valuesusing standard [**Ruby ERB templating**](https://ruby-doc.org/stdlib-2.7.1/libdoc/erb/rdoc/ERB.html).
+CSAs can also be used to declare inline IAM Role Policy and have facility for templating values using standard [**Ruby ERB templating**](https://ruby-doc.org/stdlib-2.7.1/libdoc/erb/rdoc/ERB.html).
 
 Tags you insert into the `spec.rolePolicyTemplate`, will (when rendered) be substituted with values in the `spec.policyTemplateValues` map.
 

--- a/lib/cloudsap/cli.rb
+++ b/lib/cloudsap/cli.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# Fix for https://github.com/erikhuda/thor/issues/398
+class Thor
+  module Shell
+    class Basic
+      def print_wrapped(message, options = {})
+        indent = (options[:indent] || 0).to_i
+        if indent.zero?
+          stdout.puts message
+        else
+          message.each_line do |message_line|
+            stdout.print ' ' * indent
+            stdout.puts message_line.chomp
+          end
+        end
+      end
+    end
+  end
+end
+
+# rubocop:disable Layout/HeredocIndentation
 module Cloudsap
   class CLI < Thor
     def self.exit_on_failure?
@@ -51,6 +71,40 @@ module Cloudsap
     # rubocop:enable Metrics/BlockLength
 
     desc 'controller', 'Run Cloudsap controller'
+    long_desc <<~LONGDESC
+
+    The `cloudsap contoller` subcommand launches the Cloudsap operator and
+    begins monitoring your cluster for any changes to CloudServiceAccount
+    resources.
+
+    -----------------------------------------------
+     CLI OPTION      ||  DESCRIPTION
+    -----------------------------------------------
+    --aws-region    ||  AWS region that hosts your EKS cluster (required)
+    --cluster-name  ||  Name designated for th EKS cluster (required)
+    --oidc-issuer   ||  URL of the EKS cluster's OIDC issuer
+    --kubeconfig    ||  Path to kubeconfig file for authentication
+    --debug         ||  Enable debug logging
+    -----------------------------------------------
+
+    It can be configured via commandline options above or its equivalent shell
+    environment variable.
+
+    -----------------------------------------------
+     CLI OPTION     ||  ENVIRONMENT VARIABLE
+    -----------------------------------------------
+    --aws-region    ||  AWS_REGION
+    --cluster-name  ||  CLOUDSAP_CLUSTER_NAME
+    --oidc-issuer   ||  CLOUDSAP_OIDC_ISSUER
+    --kubeconfig    ||  KUBECONFIG
+    --debug         ||  CLOUDSAP_DEBUG
+    -----------------------------------------------
+
+    For more information, visit the project homepage ...
+
+    https://github.com/dayglojesus/cloudsap
+
+    LONGDESC
     option :aws_region,   type: :string,  default: ENV['AWS_REGION'], required: true
     option :cluster_name, type: :string,  default: ENV['CLOUDSAP_CLUSTER_NAME'], required: true
     option :oidc_issuer,  type: :string,  default: ENV['CLOUDSAP_OIDC_ISSUER'], required: false
@@ -73,6 +127,53 @@ module Cloudsap
     end
 
     desc 'install COMPONENT', 'Install Cloudsap IRSA or generate install manifests'
+    long_desc <<~LONGDESC
+
+    The `cloudsap install COMPONENT` subcommand perfoms installations of
+    Cloudsap and its prerequisties:
+
+    1. `cloudsap install irsa`
+
+       Installs an AWS IAM Role for ServiceAccounts for Cloudsap itself.
+       Cloudsap requires an IRSA to begin managing the IAM resources associated
+       with any newly created `CloudServiceAccount`.
+
+    2. `cloudsap install full`
+
+       Emits a manifest you can use to install the Cloudsap operator to your
+       cluster. Once emitted, the manifest can be reviewed and edited before
+       applying it to your cluster.
+
+    2. `cloudsap install crd`
+
+       Emits a manifest containing the CRD for the CloudServiceAccounts.
+
+    -----------------------------------------------
+     CLI OPTION     ||  DESCRIPTION
+    -----------------------------------------------
+    --aws-region    ||  AWS region that hosts your EKS cluster (required)
+    --cluster-name  ||  Name designated for th EKS cluster (required)
+    --namespace     ||  Namespace in which to deploy operator (required)
+    --kubeconfig    ||  Path to kubeconfig file for authentication
+    -----------------------------------------------
+
+    It can be configured via commandline options above or its equivalent shell
+    environment variable.
+
+    -----------------------------------------------
+     CLI OPTION     ||  ENVIRONMENT VARIABLE
+    -----------------------------------------------
+    --aws-region    ||  AWS_REGION
+    --cluster-name  ||  CLOUDSAP_CLUSTER_NAME
+    --namespace     ||  CLOUDSAP_NAMESPACE
+    --kubeconfig    ||  KUBECONFIG
+    -----------------------------------------------
+
+    For more information, visit the project homepage ...
+
+    https://github.com/dayglojesus/cloudsap
+
+    LONGDESC
     option :aws_region,   type: :string, default: ENV['AWS_REGION'], required: true
     option :cluster_name, type: :string, default: ENV['CLOUDSAP_CLUSTER_NAME'], required: true
     option :namespace,    type: :string, default: ENV['CLOUDSAP_NAMESPACE'], required: true
@@ -108,3 +209,4 @@ module Cloudsap
     # rubocop:enable Metrics/MethodLength
   end
 end
+# rubocop:enable Layout/HeredocIndentation

--- a/lib/cloudsap/csa.rb
+++ b/lib/cloudsap/csa.rb
@@ -72,15 +72,16 @@ module Cloudsap
       @type        = @event[:type]
       @object      = @event[:object]
       @metadata    = @object[:metadata]
-      @status      = @object[:status] ||= {}
+      @status      = @object[:status] || {}
+      @spec        = @object[:spec] || {}
       @annotations = @metadata[:annotations]
-      @provider_id = @event[:object][:spec][:cloudProvider].to_sym
+      @provider_id = @spec[:cloudProvider]&.to_sym || :aws
     rescue StandardError => e
       log_exception(e)
     end
 
     def status=(data)
-      status.merge!(data)
+      status.deep_merge(data)
     end
 
     private

--- a/lib/cloudsap/kubernetes/sa.rb
+++ b/lib/cloudsap/kubernetes/sa.rb
@@ -46,12 +46,22 @@ module Cloudsap
           update_status(resource)
           logger.info("APPLY, #{self.class}: #{namespace}/#{name}")
         end
+      rescue => e
+        log_exception(e)
+        show_backtrace(e)
+        csa.metrics.error
+        false
       end
 
       def delete
         if delete_service_account
           logger.info("DELETE, #{self.class}: #{namespace}/#{name}")
         end
+      rescue => e
+        log_exception(e)
+        show_backtrace(e)
+        csa.metrics.error
+        false
       end
 
       private
@@ -68,6 +78,8 @@ module Cloudsap
 
       def delete_service_account
         client.delete_service_account(name, namespace)
+      rescue Kubeclient::ResourceNotFoundError => e
+        log_exception(e, :debug)
       end
 
       def service_account

--- a/lib/cloudsap/version.rb
+++ b/lib/cloudsap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Cloudsap
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
* add better inline help
* add better error handling to managed resources
  * ensure we catch, log and increment the Prometheus counters when an error occurs during the creation of deletion of a manage resource
* fix missing default values for CSA object attribs
* fix data composition bugs; missing IAM role `status` on CSA
* fix IAM policy behaviour
  * resource comparisons were not working post-create
    - If the CSA was created without a `rolePolicyTemplate` or `rolePolicyAttachments`, you could not add them. This was a bug in the comparison routine.
* update README
  * add better info on configuration and modal operation
* cleanup rubocop violations
* update CHANGELOG and bump version